### PR TITLE
bug(server): Implement LFA feedback on server

### DIFF
--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -32,6 +32,20 @@ class UserController {
     const response = UserService.logUserIn(req.body);
     return res.status(response.status).json(response);
   }
+
+  /**
+   *
+   * Updates the role of a current user to a staff role
+   * @static
+   * @param {Object} req
+   * @param {Object} res
+   * @returns {Object} JSON API Response
+   * @memberof UserController
+   */
+  static makeStaff(req, res) {
+    const response = UserService.makeStaff(req.body.email);
+    return res.status(response.status).json(response);
+  }
 }
 
 export default UserController;

--- a/server/src/helpers/helper.js
+++ b/server/src/helpers/helper.js
@@ -60,9 +60,9 @@ class Helper {
     if (!value) {
       return {
         status: 422,
+        success: false,
         error: `Invalid ${field} provided`,
-        message: `${field} cannot be empty`,
-        success: false
+        message: `${field} cannot be empty`
       };
     }
     return false;
@@ -79,9 +79,9 @@ class Helper {
     if (/\s/.test(value)) {
       return {
         status: 422,
+        success: false,
         error: `Invalid ${field} provided`,
-        message: `No whitespaces allowed in ${field}`,
-        success: false
+        message: `No whitespaces allowed in ${field}`
       };
     }
     return false;
@@ -99,9 +99,9 @@ class Helper {
     if (!pattern.test(value)) {
       return {
         status: 422,
+        success: false,
         error: `Invalid ${field} provided`,
-        message: `${field} must be Alphabetical`,
-        success: false
+        message: `${field} must be Alphabetical`
       };
     }
     return false;

--- a/server/src/middleware/AccountValidator.js
+++ b/server/src/middleware/AccountValidator.js
@@ -20,18 +20,18 @@ class AccountValidation {
     if (!Number(acctNumber)) {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `Request forbidden`,
-        message: `Account Number must be a Number`,
-        success: false
+        message: `Account Number must be a Number`
       });
     }
 
     if (!acctNumber.startsWith(102) || acctNumber.length !== 10) {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `Request Forbidden`,
-        message: `Account Number must be 10 digits and begin with the digits 102`,
-        success: false
+        message: `Account Number must be 10 digits and begin with the digits 102`
       });
     }
 
@@ -108,9 +108,9 @@ class AccountValidation {
     if (!emailPattern.test(email)) {
       return res.status(422).json({
         status: 422,
+        success: false,
         error: 'Invalid email address',
-        message: 'Please provide a valid email address',
-        success: false
+        message: 'Please provide a valid email address'
       });
     }
 
@@ -136,10 +136,10 @@ class AccountValidation {
   static inputCheck(firstName, lastName, email, type) {
     const errors = [];
     let isEmpty;
-    isEmpty = helper.checkFieldEmpty(firstName, 'firstname');
+    isEmpty = helper.checkFieldEmpty(firstName, 'firstName');
     if (isEmpty) errors.push(isEmpty);
 
-    isEmpty = helper.checkFieldEmpty(lastName, 'lastname');
+    isEmpty = helper.checkFieldEmpty(lastName, 'lastName');
     if (isEmpty) errors.push(isEmpty);
 
     isEmpty = helper.checkFieldEmpty(email, 'email');
@@ -149,10 +149,10 @@ class AccountValidation {
     if (isEmpty) errors.push(isEmpty);
 
     let hasWhiteSpace;
-    hasWhiteSpace = helper.checkFieldWhiteSpace(firstName, 'firstname');
+    hasWhiteSpace = helper.checkFieldWhiteSpace(firstName, 'firstName');
     if (hasWhiteSpace) errors.push(hasWhiteSpace);
 
-    hasWhiteSpace = helper.checkFieldWhiteSpace(lastName, 'lastname');
+    hasWhiteSpace = helper.checkFieldWhiteSpace(lastName, 'lastName');
     if (hasWhiteSpace) errors.push(hasWhiteSpace);
 
     hasWhiteSpace = helper.checkFieldWhiteSpace(email, 'email');
@@ -162,10 +162,10 @@ class AccountValidation {
     if (hasWhiteSpace) errors.push(hasWhiteSpace);
 
     let isNotAlpha;
-    isNotAlpha = helper.checkFieldAlpha(firstName, 'firstname');
+    isNotAlpha = helper.checkFieldAlpha(firstName, 'firstName');
     if (isNotAlpha) errors.push(isNotAlpha);
 
-    isNotAlpha = helper.checkFieldAlpha(lastName, 'lastname');
+    isNotAlpha = helper.checkFieldAlpha(lastName, 'lastName');
     if (isNotAlpha) errors.push(isNotAlpha);
 
     isNotAlpha = helper.checkFieldAlpha(type, 'account type');

--- a/server/src/middleware/Auth.js
+++ b/server/src/middleware/Auth.js
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -28,9 +27,8 @@ class Auth {
 
       req.userId = decoded.id;
       req.userEmail = decoded.email;
-      req.userFirstName = decoded.firstName;
-      req.userLastName = decoded.lastName;
       req.userType = decoded.type;
+      req.isAdmin = decoded.isAdmin;
 
       return next();
     } catch (e) {
@@ -55,8 +53,29 @@ class Auth {
     if (req.userType !== 'staff') {
       return res.status(401).json({
         status: 401,
-        error: `You are not Authorized to perform this Action`,
-        success: false
+        success: false,
+        error: `You are not Authorized to perform this Action`
+      });
+    }
+    return next();
+  }
+
+  /**
+   *
+   * Checks if the current user is an admin or not and applies appropriate access control
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {(function|Object)} Function next() or an error Object
+   * @memberof Auth
+   */
+  static adminCheck(req, res, next) {
+    if (req.isAdmin !== true) {
+      return res.status(401).json({
+        status: 401,
+        success: false,
+        error: `You are not Authorized to perform this Action`
       });
     }
     return next();

--- a/server/src/middleware/TransactionValidator.js
+++ b/server/src/middleware/TransactionValidator.js
@@ -26,18 +26,18 @@ class TransactionValidation {
     if (!Number(amount)) {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `Request Forbidden`,
-        message: `Transaction amount must be a number`,
-        success: false
+        message: `Transaction amount must be a number`
       });
     }
 
     if (Number(amount) < 500) {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `Request Forbidden`,
-        message: `You can only make debit/credit transactions above 500 Naira`,
-        success: false
+        message: `You can only make debit/credit transactions above 500 Naira`
       });
     }
 
@@ -56,9 +56,9 @@ class TransactionValidation {
     if (transactionType === 'invalid') {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `request forbidden`,
-        message: `Transaction type can only be 'debit' or 'credit'`,
-        success: false
+        message: `Transaction type can only be 'debit' or 'credit'`
       });
     }
 
@@ -73,9 +73,9 @@ class TransactionValidation {
     if (urltype !== type) {
       return res.status(403).json({
         status: 403,
+        success: false,
         error: `Request forbidden`,
-        message: `Please confirm that the url matches the transaction type`,
-        success: false
+        message: `Please confirm that the url matches the transaction type`
       });
     }
 

--- a/server/src/middleware/UserValidator.js
+++ b/server/src/middleware/UserValidator.js
@@ -17,16 +17,16 @@ class UserValidation {
    * @memberof UserValidation
    */
   static signUpCheck(req, res, next) {
-    let { email, firstName, lastName, password, type } = req.body;
+    let { email, firstName, lastName, password, confirmPassword } = req.body;
 
-    const errors = UserValidation.inputCheck(email, firstName, lastName, password, type);
+    const errors = UserValidation.inputCheck(email, firstName, lastName, password, confirmPassword);
     if (errors.length > 0) return res.status(errors[0].status).json(errors[0]);
 
     if (firstName) firstName = firstName.trim();
     if (lastName) lastName = lastName.trim();
-    if (type) type = type.trim();
     if (email) email = email.trim();
     if (password) password = password.trim();
+    if (confirmPassword) confirmPassword = confirmPassword.trim();
 
     const passwordPattern = /\w{6,}/g;
 
@@ -35,6 +35,15 @@ class UserValidation {
         status: 406,
         error: 'Invalid password provided',
         message: `Password must not be less than six(6) characters`,
+        success: false
+      });
+    }
+
+    if (password !== confirmPassword) {
+      return res.status(422).json({
+        status: 422,
+        error: 'Invalid password provided',
+        message: `Passwords do not match`,
         success: false
       });
     }
@@ -80,7 +89,6 @@ class UserValidation {
     req.body.firstName = firstName;
     req.body.lastName = lastName;
     req.body.password = password;
-    req.body.type = type;
     req.body.email = email;
 
     return next();
@@ -133,13 +141,13 @@ class UserValidation {
    * @returns {Array} an array of error(s)
    * @memberof UserValidation
    */
-  static inputCheck(email, firstName, lastName, password, type) {
+  static inputCheck(email, firstName, lastName, password, confirmPassword) {
     const errors = [];
     let isEmpty;
-    isEmpty = helper.checkFieldEmpty(firstName, 'firstname');
+    isEmpty = helper.checkFieldEmpty(firstName, 'firstName');
     if (isEmpty) errors.push(isEmpty);
 
-    isEmpty = helper.checkFieldEmpty(lastName, 'lastname');
+    isEmpty = helper.checkFieldEmpty(lastName, 'lastName');
     if (isEmpty) errors.push(isEmpty);
 
     isEmpty = helper.checkFieldEmpty(email, 'email');
@@ -148,7 +156,7 @@ class UserValidation {
     isEmpty = helper.checkFieldEmpty(password, 'password');
     if (isEmpty) errors.push(isEmpty);
 
-    isEmpty = helper.checkFieldEmpty(type, 'user type');
+    isEmpty = helper.checkFieldEmpty(confirmPassword, 'confirmPassword');
     if (isEmpty) errors.push(isEmpty);
 
     let hasWhiteSpace;
@@ -164,17 +172,11 @@ class UserValidation {
     hasWhiteSpace = helper.checkFieldWhiteSpace(password, 'password');
     if (hasWhiteSpace) errors.push(hasWhiteSpace);
 
-    hasWhiteSpace = helper.checkFieldWhiteSpace(type, 'user type');
-    if (hasWhiteSpace) errors.push(hasWhiteSpace);
-
     let isNotAlpha;
-    isNotAlpha = helper.checkFieldAlpha(firstName, 'firstname');
+    isNotAlpha = helper.checkFieldAlpha(firstName, 'firstName');
     if (isNotAlpha) errors.push(isNotAlpha);
 
-    isNotAlpha = helper.checkFieldAlpha(lastName, 'lastname');
-    if (isNotAlpha) errors.push(isNotAlpha);
-
-    isNotAlpha = helper.checkFieldAlpha(type, 'user type');
+    isNotAlpha = helper.checkFieldAlpha(lastName, 'lastName');
     if (isNotAlpha) errors.push(isNotAlpha);
 
     return errors;

--- a/server/src/models/mockData.js
+++ b/server/src/models/mockData.js
@@ -1,5 +1,27 @@
 export default {
-  users: [],
+  users: [
+    {
+      id: 1,
+      email: 'user@admin.com',
+      password: '$2b$10$aRUut8DBn7YgO5eVBW4uFeB47YMFMOrLRxf6jylsAKl1eEwYUYY9m',
+      type: 'staff',
+      isAdmin: true
+    },
+    {
+      id: 2,
+      email: 'user@staff.com',
+      password: '$2b$10$g0tV.Pdv.CEZFyI1Tecy0.CSjNAdzM6kGyB/KSPqBbBprz4EGgjpq',
+      type: 'staff',
+      isAdmin: false
+    },
+    {
+      id: 3,
+      email: 'user2@staff.com',
+      password: '$2b$10$zJF.wRMevlFGfphFDKBPDufEPXaLrJy8RaYFGx7spc6cxTwmETOhm',
+      type: 'staff',
+      isAdmin: false
+    }
+  ],
   accounts: [
     {
       id: 1,

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -15,7 +15,7 @@ class User {
    * @param {boolean} [isAdmin=false]
    * @memberof User
    */
-  constructor(id, email, firstName, lastName, password, type, isAdmin = false) {
+  constructor(id, email, firstName, lastName, password, type = 'client', isAdmin = false) {
     this.id = id;
     this.email = email;
     this.firstName = firstName;

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -4,12 +4,16 @@ import UserController from '../controllers/user.controller';
 
 import UserValidation from '../middleware/UserValidator';
 
+import Auth from '../middleware/Auth';
+
 const { signUpCheck, loginCheck } = UserValidation;
-const { createUser, logUserIn } = UserController;
+const { createUser, logUserIn, makeStaff } = UserController;
+const { getUser, adminCheck } = Auth;
 
 const userRouter = Router();
 
 userRouter.post('/signup', signUpCheck, createUser);
 userRouter.post('/signin', loginCheck, logUserIn);
+userRouter.put('/makestaff', getUser, adminCheck, makeStaff);
 
 export default userRouter;

--- a/server/src/services/account.service.js
+++ b/server/src/services/account.service.js
@@ -22,9 +22,9 @@ class AccountService {
     if (email !== userEmail)
       return {
         status: 403,
+        success: false,
         error: 'Request Forbidden',
-        message: 'You can only create a bank account with your registered e-mail',
-        success: false
+        message: 'You can only create a bank account with your registered e-mail'
       };
 
     const id = mockData.accounts.length + 1;
@@ -37,9 +37,9 @@ class AccountService {
 
     return {
       status: 201,
+      success: true,
       data: { accountNumber, firstName, lastName, email, type, balance, status },
-      message: `New ${type} account created successfully`,
-      success: true
+      message: `New ${type} account created successfully`
     };
   }
 
@@ -68,8 +68,8 @@ class AccountService {
     if (status === 'invalid') {
       return {
         status: 403,
-        error: `Status can only be 'activate' or 'deactivate'`,
-        success: false
+        success: false,
+        error: `Status can only be 'activate' or 'deactivate'`
       };
     }
 
@@ -83,15 +83,15 @@ class AccountService {
       mockData.accounts.splice(accountIndex, 1, foundAccount);
       return {
         status: 202,
-        data: { accountNumber, status },
         success: true,
+        data: { accountNumber, status },
         message: `Account ${validStatus}d succesfully`
       };
     }
     return {
       status: 404,
-      error: `Not Found`,
       success: false,
+      error: `Not Found`,
       message: `Account does not exist`
     };
   }
@@ -112,9 +112,9 @@ class AccountService {
     if (foundAccount) {
       const accountIndex = mockData.accounts.indexOf(foundAccount);
       mockData.accounts.splice(accountIndex, 1);
-      return { status: 200, message: `Account sucessfully deleted`, success: true };
+      return { status: 200, success: true, message: `Account sucessfully deleted` };
     }
-    return { status: 404, error: `Not found`, message: `Account does not exist`, success: false };
+    return { status: 404, success: false, error: `Not found`, message: `Account does not exist` };
   }
 }
 

--- a/server/src/services/transaction.service.js
+++ b/server/src/services/transaction.service.js
@@ -34,8 +34,8 @@ class TransactionService {
       ) {
         return {
           status: 403,
-          error: `Request Forbidden`,
           success: false,
+          error: `Request Forbidden`,
           message: `Insufficient Funds. You have ${oldBalance} Naira left`
         };
       }
@@ -43,8 +43,8 @@ class TransactionService {
       if (foundAccount.status !== 'active') {
         return {
           status: 403,
-          error: `Request forbidden`,
           success: false,
+          error: `Request forbidden`,
           message: `Account status:${
             foundAccount.status
           }. You can only perform transactions on an active account.`
@@ -83,6 +83,7 @@ class TransactionService {
 
       return {
         status: 201,
+        success: true,
         data: {
           transactionId: id,
           accountNumber: parseInt(accountNumber, 10),
@@ -94,7 +95,7 @@ class TransactionService {
         message: `Account ${transactionType}ed successfully`
       };
     }
-    return { status: 404, error: `Not found`, message: `Account does not exist`, success: false };
+    return { status: 404, success: false, error: `Not found`, message: `Account does not exist` };
   }
 }
 

--- a/server/src/services/user.service.js
+++ b/server/src/services/user.service.js
@@ -16,19 +16,21 @@ class UserService {
    * @memberof UserService
    */
   static createUser(newUser) {
-    const { email, firstName, lastName, password, type, isAdmin } = newUser;
+    const { email, firstName, lastName, password } = newUser;
     const hashedpassword = Helper.hashPassword(password);
 
     const id = mockData.users.length + 1;
-    const userInstance = new User(id, email, firstName, lastName, hashedpassword, type, isAdmin);
+    const userInstance = new User(id, email, firstName, lastName, hashedpassword);
     mockData.users.push(userInstance);
 
-    const payLoad = { id, firstName, lastName, email, type };
+    const { isAdmin, type } = userInstance;
+    const payLoad = { id, email, isAdmin, type };
     const token = Helper.getToken(payLoad);
     return {
       status: 201,
-      data: { token, id, firstName, lastName, email, type },
-      success: true
+      success: true,
+      data: { id, firstName, lastName, email, token },
+      message: `New Account created successfully`
     };
   }
 
@@ -46,27 +48,52 @@ class UserService {
     if (!foundUser)
       return {
         status: 401,
-        error: 'Authentication Failed. Invalid Login credentials provided',
-        success: false
+        success: false,
+        error: 'Authentication Failed. Invalid Login credentials provided'
       };
 
     const hash = foundUser.password;
     if (Helper.comparePassword(password, hash) === true) {
-      const { id, firstName, lastName, type } = foundUser;
-      const payLoad = { id, firstName, lastName, email, type };
+      const { id, firstName, lastName, isAdmin, type } = foundUser;
+      const payLoad = { id, firstName, lastName, email, isAdmin, type };
       const token = Helper.getToken(payLoad);
       return {
         status: 200,
-        data: { token, id, firstName, lastName, email, type },
-        success: true
+        success: true,
+        data: { id, firstName, lastName, email, token },
+        message: `User Log In Successful`
       };
     }
 
     return {
       status: 401,
-      error: 'Authentication Failed. Invalid Login credentials provided',
-      success: false
+      success: false,
+      error: 'Authentication Failed. Invalid Login credentials provided'
     };
+  }
+
+  /**
+   *
+   * Updates the role of a current user to a staff role
+   * @static
+   * @param {string} staffEmail
+   * @returns
+   * @memberof UserService
+   */
+  static makeStaff(staffEmail) {
+    const foundUser = mockData.users.find(user => user.email === staffEmail);
+    if (foundUser) {
+      const userIndex = mockData.accounts.indexOf(foundUser);
+      foundUser.type = 'staff';
+      mockData.accounts.splice(userIndex, 1, foundUser);
+      return {
+        status: 202,
+        success: true,
+        data: foundUser,
+        message: `User type updated succesfully`
+      };
+    }
+    return { status: 404, success: false, error: `Not found`, message: `User does not exist` };
   }
 }
 

--- a/server/src/tests/accounts.test.js
+++ b/server/src/tests/accounts.test.js
@@ -16,13 +16,10 @@ describe('Tests for all accounts Endpoints', () => {
   before(done => {
     chai
       .request(app)
-      .post('/api/v1/auth/signup')
+      .post('/api/v1/auth/signin')
       .send({
-        firstName: 'jon',
-        lastName: 'doe',
-        email: 'jdee@gmail.com',
-        password: 'complexandbitter',
-        type: 'staff'
+        email: 'user@staff.com',
+        password: 'staffuser'
       })
       .end((err, res) => {
         const { token } = res.body.data;
@@ -117,7 +114,7 @@ describe('Tests for all accounts Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('firstname cannot be empty');
+          expect(res.body.message).to.be.equal('firstName cannot be empty');
           done();
         });
     });
@@ -137,7 +134,7 @@ describe('Tests for all accounts Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('lastname cannot be empty');
+          expect(res.body.message).to.be.equal('lastName cannot be empty');
           done();
         });
     });
@@ -195,7 +192,7 @@ describe('Tests for all accounts Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('firstname must be Alphabetical');
+          expect(res.body.message).to.be.equal('firstName must be Alphabetical');
           done();
         });
     });
@@ -215,7 +212,7 @@ describe('Tests for all accounts Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('lastname must be Alphabetical');
+          expect(res.body.message).to.be.equal('lastName must be Alphabetical');
           done();
         });
     });

--- a/server/src/tests/transaction.test.js
+++ b/server/src/tests/transaction.test.js
@@ -15,13 +15,10 @@ describe('Tests for all transaction Endpoints', () => {
   before(done => {
     chai
       .request(app)
-      .post('/api/v1/auth/signup')
+      .post('/api/v1/auth/signin')
       .send({
-        firstName: 'new',
-        lastName: 'staff',
-        email: 'staff@gmail.com',
-        password: 'newsheriffintown',
-        type: 'staff'
+        email: 'user2@staff.com',
+        password: 'staffuser2'
       })
       .end((err, res) => {
         const { token } = res.body.data;

--- a/server/src/tests/user.test.js
+++ b/server/src/tests/user.test.js
@@ -25,14 +25,7 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
         .end((err, res) => {
           expect(res).to.have.status(201);
           expect(res.body.status).to.be.equal(201);
-          expect(res.body.data).to.have.keys(
-            'token',
-            'id',
-            'firstName',
-            'lastName',
-            'email',
-            'type'
-          );
+          expect(res.body.data).to.have.keys('token', 'id', 'firstName', 'lastName', 'email');
           expect(res.body.data.token).to.be.a('string');
           done();
         });
@@ -52,7 +45,7 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.error).to.be.equal('Invalid firstname provided');
+          expect(res.body.error).to.be.equal('Invalid firstName provided');
           done();
         });
     });
@@ -71,7 +64,7 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.error).to.be.equal('Invalid lastname provided');
+          expect(res.body.error).to.be.equal('Invalid lastName provided');
           done();
         });
     });
@@ -91,25 +84,6 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
           expect(res.body.error).to.be.equal('Invalid email provided');
-          done();
-        });
-    });
-    it('Should return an error if a user tries to sign up without specifying user type', done => {
-      chai
-        .request(app)
-        .post('/api/v1/auth/signup')
-        .send({
-          firstName: 'jon',
-          lastName: 'bellion',
-          email: 'jon@gmail.com',
-          password: 'simpleandweet',
-          type: ''
-        })
-        .end((err, res) => {
-          expect(res).to.have.status(422);
-          expect(res.body.status).to.be.equal(422);
-          expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.error).to.be.equal('Invalid user type provided');
           done();
         });
     });
@@ -166,7 +140,7 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('firstname must be Alphabetical');
+          expect(res.body.message).to.be.equal('firstName must be Alphabetical');
           done();
         });
     });
@@ -185,29 +159,11 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
           expect(res).to.have.status(422);
           expect(res.body.status).to.be.equal(422);
           expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('lastname must be Alphabetical');
+          expect(res.body.message).to.be.equal('lastName must be Alphabetical');
           done();
         });
     });
-    it('Should return an error if a user tries to sign up with a non-alpabetic user type', done => {
-      chai
-        .request(app)
-        .post('/api/v1/auth/signup')
-        .send({
-          firstName: 'jon',
-          lastName: 'bellion',
-          email: 'jon@gmail.com',
-          password: 'simpleandweet',
-          type: '#.'
-        })
-        .end((err, res) => {
-          expect(res).to.have.status(422);
-          expect(res.body.status).to.be.equal(422);
-          expect(res.body).to.have.keys('status', 'error', 'message', 'success');
-          expect(res.body.message).to.be.equal('user type must be Alphabetical');
-          done();
-        });
-    });
+
     it('Should return an error if a user tries to sign up with an invalid email address', done => {
       chai
         .request(app)
@@ -259,15 +215,8 @@ describe('Tests for all Auth(signup and signin) Endpoints', () => {
         .end((err, res) => {
           expect(res).to.have.status(200);
           expect(res.body.status).to.be.equal(200);
-          expect(res.body).to.have.keys('status', 'data', 'success');
-          expect(res.body.data).to.have.keys(
-            'token',
-            'id',
-            'firstName',
-            'lastName',
-            'email',
-            'type'
-          );
+          expect(res.body).to.have.keys('status', 'data', 'success', 'message');
+          expect(res.body.data).to.have.key('token', 'id', 'firstName', 'lastName', 'email');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
-Implement LFA feedback on server


#### Description of Task to be completed?
- update lastname and firstname in response to match input fields
- move success message in all responses upwards
- add confirm password field on signup
- add validation for confirm password field
- move token downwards on both auth endpoints
- remove type parameter specified in input field
- set type parameter to client by default in user model
- write controller and service methods to update user to staff
- write and mount auth middleware on makeStaff route to restrict access
to admin users only
- update tests
- fixes[#165378228]

#### How should this be manually tested?
- Clone the repository using ```git clone https://github.com/fxola/Banka.git .``` in your terminal
- run ```npm install``` on your terminal
- run ```npm run start``` to start up the server
- run ```npm run test``` to see test results
- to make a staff user, sign up a new user, then login in with the credentials
```
{
 "email":"user@admin.com",
 "password":"adminuser"
}
```
- then make a PUT request to  the ```api/v1/auth/makestafff``` endpoint specifying the newly signed user email in the request body like so
```
{
 "email":"newlysignedup@user.com"
}
```

#### Any background context you want to provide?
- Create and environment variable with the format ```SECRET = yoursecret``` in the root of the server directory
- This endpoint is only accessible to an Admin user

#### What are the relevant pivotal tracker stories?
- PT Story link - [#165378228] (https://www.pivotaltracker.com/n/projects/2321791/stories/165378228)

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A