### PR TITLE
#165492904 Refactor admin make staff endpoint to use database

### DIFF
--- a/server/src/models/UserModel.js
+++ b/server/src/models/UserModel.js
@@ -49,6 +49,21 @@ class User {
     const { rowCount } = await db.query(query, [email]);
     return rowCount;
   }
+
+  /**
+   *
+   * Handles the update of a user role in the database
+   * @static
+   * @param {number} accountNumber
+   * @param {string} value new updated value
+   * @param {string} column column to be updated
+   * @memberof Account
+   */
+  static async updateRole(email, type) {
+    const query = `update users set type = $1 where email = $2 returning *`;
+    const { rows } = await db.query(query, [type, email]);
+    return rows[0];
+  }
 }
 
 export default User;

--- a/server/src/services/AccountService.js
+++ b/server/src/services/AccountService.js
@@ -28,6 +28,22 @@ class AccountService {
         error: 'Request Forbidden',
         message: 'You can only create a bank account with your registered e-mail'
       };
+    let isValid;
+    switch (type) {
+      case 'savings':
+      case 'current':
+        isValid = true;
+        break;
+      default:
+        isValid = false;
+    }
+    if (!isValid)
+      return {
+        status: 403,
+        success: false,
+        error: `Invalid account type provided`,
+        message: `Type can only be 'savings' or 'current'`
+      };
 
     const newAccount = await Account.create(accountDetails, userId);
     const { accountnumber, balance, status } = newAccount;

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -1,4 +1,3 @@
-import mockData from '../models/mockData';
 import Helper from '../helpers/helper';
 import User from '../models/UserModel';
 /**
@@ -55,8 +54,15 @@ class UserService {
 
     const hash = foundUser.password;
     if (Helper.comparePassword(password, hash) === true) {
-      const { id, firstname, lastname, isAdmin, type } = foundUser;
-      const payLoad = { id, firstName: firstname, lastName: lastname, email, isAdmin, type };
+      const { id, firstname, lastname, isadmin, type } = foundUser;
+      const payLoad = {
+        id,
+        firstName: firstname,
+        lastName: lastname,
+        email,
+        isAdmin: isadmin,
+        type
+      };
       const token = Helper.getToken(payLoad);
       return {
         status: 200,
@@ -81,16 +87,15 @@ class UserService {
    * @returns
    * @memberof UserService
    */
-  static makeStaff(staffEmail) {
-    const foundUser = mockData.users.find(user => user.email === staffEmail);
+  static async makeStaff(staffEmail) {
+    const foundUser = await User.findByEmail(staffEmail);
     if (foundUser) {
-      const userIndex = mockData.accounts.indexOf(foundUser);
-      foundUser.type = 'staff';
-      mockData.accounts.splice(userIndex, 1, foundUser);
+      const type = 'staff';
+      const { password, ...updatedUser } = await User.updateRole(staffEmail, type);
       return {
-        status: 202,
+        status: 200,
         success: true,
-        data: foundUser,
+        data: updatedUser,
         message: `User type updated succesfully`
       };
     }

--- a/server/src/tests/accounts.test.js
+++ b/server/src/tests/accounts.test.js
@@ -257,6 +257,25 @@ describe('Tests for all accounts Endpoints', () => {
           done();
         });
     });
+    it('Should return an error if a client tries to create an account with an invalid account type', done => {
+      chai
+        .request(app)
+        .post('/api/v1/accounts')
+        .set('Authorization', `Bearer ${clientToken}`)
+        .send({
+          firstName: 'jon',
+          lastName: 'bellion',
+          email: 'second@user.com',
+          type: 'neithersavingsnorcurrent'
+        })
+        .end((err, res) => {
+          expect(res).to.have.status(403);
+          expect(res.body.status).to.be.equal(403);
+          expect(res.body).to.have.keys('status', 'error', 'message', 'success');
+          expect(res.body.message).to.be.equal(`Type can only be 'savings' or 'current'`);
+          done();
+        });
+    });
     it('Should return an error if a client tries to create an account with an invalid email address', done => {
       chai
         .request(app)


### PR DESCRIPTION
#### What does this PR do?
- Refactor  PUT  ```api/v1/auth/makestaff``` to use database


#### Description of Task to be completed?
- create update role method in user model to handle role change
- refactor makestaff service method to use database
- fix isadmin typo in log in payload
- validate account type in create account method
- write tests for make staff functionality
- write tests for invalid account type
- finishes[#165492904]

#### How should this be manually tested?
- Clone the repository using ```git clone https://github.com/fxola/Banka.git .``` in your terminal
- run ```npm install``` on your terminal
- run ```npm run test``` to see test results


#### Any background context you want to provide?
- refer to the env.example file for configuration details

#### What are the relevant pivotal tracker stories?
- PT Story link - [#165492904] (https://www.pivotaltracker.com/n/projects/2321791/stories/165492904)

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A